### PR TITLE
refactor(webhooks): remove 'micro' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@stripe/react-stripe-js": "1.1.2",
     "@stripe/stripe-js": "1.5.0",
     "dotenv": "latest",
-    "micro": "^9.3.4",
     "micro-cors": "^0.1.1",
     "next": "latest",
     "react": "^16.12.0",
@@ -22,7 +21,6 @@
     "use-shopping-cart": "2.1.0"
   },
   "devDependencies": {
-    "@types/micro": "^7.3.3",
     "@types/micro-cors": "^0.1.0",
     "@types/node": "^13.1.2",
     "@types/react": "^16.9.17",


### PR DESCRIPTION
Also don't bother to stringify buffer since `constructEvent` accepts type `string | Buffer`