### PR TITLE
Check if status is available before accessing it

### DIFF
--- a/components/ElementsForm.tsx
+++ b/components/ElementsForm.tsx
@@ -159,15 +159,12 @@ const ElementsForm = () => {
         <button
           className="elements-style-background"
           type="submit"
-          disabled={
-            !['initial', 'succeeded', 'error'].includes(payment.status) ||
-            !stripe
-          }
+          disabled={!stripe}
         >
           Donate {formatAmountForDisplay(input.customDonation, config.CURRENCY)}
         </button>
       </form>
-      <PaymentStatus status={payment.status} />
+      {payment?.status && <PaymentStatus status={payment.status} />}
       <PrintObject content={payment} />
     </>
   );


### PR DESCRIPTION
## Details
The page crashes when an intent is being created as `payment.status` is not available, I added a check before accessing it but I had to remove the check if payment status equals one of those given status to disable the button, maybe simply disable on submission and re-enable it when the form is submitted?